### PR TITLE
Rename commands for lock state requests

### DIFF
--- a/views/pages/docs.ejs
+++ b/views/pages/docs.ejs
@@ -335,7 +335,7 @@ npm install node-red-contrib-alexa-home-skill</pre>
       requests setting the <i>msg.payload</i> of the input message to true/false to signify success or failure.</p>
 
       <p>For SetTargetTemperatureRequest, IncrementTargetTemperatureRequest, DecrementTargetTemperatureRequest, GetTemperatureReadingRequest, 
-      GetTargetTemperatureRequest, GetLockStateRequestRequest request you must also include a <i>msg.extra</i> object.
+      GetTargetTemperatureRequest, GetLockStateRequest request you must also include a <i>msg.extra</i> object.
       <p>When the input value is outside the supported range, the <i>msg.extra</i> should look like this:</p>
       <pre>{
     min: 10.0,


### PR DESCRIPTION
Alexa uses GetLockStateRequest and SetLockStateRequest, not SetLockState and GetLockState

In my Lock Device, Alexa used GetLockStateRequest and SetLockStateRequest, not SetLockState and GetLockState.